### PR TITLE
Undid an accidental change that caused weird item preview behavior

### DIFF
--- a/ItemPreviewImproved.lua
+++ b/ItemPreviewImproved.lua
@@ -801,9 +801,7 @@ function ItemPreviewImproved:HelperBuildItemTooltip(luaCaller, wndArg, item)
 	wndArg:SetData(item)
 end
 
-function ItemPreviewImproved:OnShowItemInDressingRoom(nItemSlot)
-	local item = Item.GetItemFromInventoryLoc(nItemSlot)
-
+function ItemPreviewImproved:OnShowItemInDressingRoom(item)
 	self.addonPreview = Apollo.GetAddon("ItemPreview")
 		if self.addonPreview ~= nil then
 			if self.addonPreview.wndMain and self.addonPreview.wndMain:IsShown() then


### PR DESCRIPTION
Think you made that change by accident? 
the argument to OnShowItemInDressingRoom is still an item object and not the slot index, calling GetItemFromInventoryLoc on it worked but returned an erroneous item for me (specifically some chest piece) which made my char take off my chest in the preview window ^^
